### PR TITLE
fix: TypeError: range() integer end argument expected, got str.

### DIFF
--- a/pygoogle.py
+++ b/pygoogle.py
@@ -65,7 +65,7 @@ If this header is not present, a value of en is assumed.
 
 class pygoogle:
     def __init__(self, query, pages=10, hl='en', log_level=logging.INFO):
-        self.pages = pages  #Number of pages. default 10
+        self.pages = int(pages)  #Number of pages. default 10
         self.query = query
         self.filter = FILTER_ON  #Controls turning on or off the duplicate content filter. On = 1.
         self.rsz = RSZ_LARGE  #Results per page. small = 4 /large = 8


### PR DESCRIPTION
> >  python pygoogle.py test -p 10

Traceback (most recent call last):
  File "pygoogle.py", line 232, in <module>
    main()
  File "pygoogle.py", line 228, in main
    search.display_results()
  File "pygoogle.py", line 208, in display_results
    self.**search**(True)
  File "pygoogle.py", line 89, in **search**
    for page in range(0, self.pages):
